### PR TITLE
Add view command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,37 @@ Lint your CODEOWNERS file.
 
 ## Usage
 
-Render unknown owners red based on the current branch's CODEOWNERS errors reported by GitHub:
+Render a list of errors based on the current branch's CODEOWNERS errors reported by GitHub:
 
 ```bash
 gh codeowners lint
 ```
 
-You can also get a sorted list of unknown owners:
+You can also get a sorted list of unknown owners or just return the raw JSON:
 
 ```bash
 gh codeowners lint --unknown-owners
+gh codeowners lint --json
+```
+
+To render your CODEOWNERS file with errors reported by GitHub:
+
+```bash
+gh codeowners view
+```
+
+## Configuration
+
+This extension will render colors whenever possible and, in some scenarios like when printing a list of errors,
+maybe change the format to prefer colors over markers that may work better only for non-colored text.
+
+You can override these colors on the command line (pass `--help` for details) or permanently with a configuration file
+located under your home directory on all platforms: _~/.config/gh-codeowners/config.yml_
+
+```yaml
+color:
+  comment: "#6A9955"
+  error:   "#F44747"
 ```
 
 ## License

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,12 @@ go 1.18
 require (
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.2
+	gopkg.in/h2non/gock.v1 v1.1.2
 )
 
 require (
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
+	github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -131,6 +131,7 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
 github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 h1:2VTzZjLZBgl62/EtslCrtky5vbi9dd7HrQPQIx6wqiw=
+github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542/go.mod h1:Ow0tF8D4Kplbc8s8sSb3V2oUCygFHVp8gC3Dn6U4MNI=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
@@ -172,6 +173,8 @@ github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/muesli/reflow v0.3.0 h1:IFsN6K9NfGtjeggFP+68I4chLZV2yIKsXJFNZ+eWh6s=
 github.com/muesli/termenv v0.12.0 h1:KuQRUE3PgxRFWhq4gHvZtPSLCGDqM5q/cYr1pZ39ytc=
 github.com/muesli/termenv v0.12.0/go.mod h1:WCCv32tusQ/EEZ5S8oUIIrC/nIuBcxCVqlN4Xfkv+7A=
+github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 h1:W6apQkHrMkS0Muv8G/TipAy/FJl/rCYT0+EuS8+Z0z4=
+github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
 github.com/pelletier/go-toml/v2 v2.0.6 h1:nrzqCb7j9cDFj2coyLNLaZuJTLjWjlaz6nvTvIwycIU=
 github.com/pelletier/go-toml/v2 v2.0.6/go.mod h1:eumQOmlWiOPt5WriQQqoM5y18pDHwha2N+QD+EUNTek=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -521,6 +524,7 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/h2non/gock.v1 v1.1.2 h1:jBbHXgGBK/AoPVfJh5x4r/WxIrElvbLel8TCZkkZJoY=
+gopkg.in/h2non/gock.v1 v1.1.2/go.mod h1:n7UGz/ckNChHiK05rDoiC4MYSunEC/lyaUm2WWaDva0=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/internal/cmd/lint.go
+++ b/internal/cmd/lint.go
@@ -1,26 +1,34 @@
 package cmd
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
+	"strings"
 
 	"github.com/cli/go-gh"
 	"github.com/cli/go-gh/pkg/api"
+	"github.com/cli/go-gh/pkg/jsonpretty"
 	"github.com/heaths/gh-codeowners/internal/codeowners"
 	"github.com/heaths/gh-codeowners/internal/git"
-	"github.com/shurcooL/graphql"
 	"github.com/spf13/cobra"
 )
 
+const (
+	indent = "  "
+)
+
 func LintCommand(globalOpts *GlobalOptions) *cobra.Command {
-	opts := &lintOptions{}
+	opts := &lintOptions{
+		GlobalOptions: globalOpts,
+	}
 
 	cmd := &cobra.Command{
 		Use:   "lint",
 		Short: "Checks CODEOWNERS for errors",
 		Long:  "Checks your CODEOWNERS files for errors as determined by GitHub.",
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			opts.GlobalOptions = globalOpts
-
 			err = opts.EnsureRepository()
 			if err != nil {
 				return
@@ -36,8 +44,9 @@ func LintCommand(globalOpts *GlobalOptions) *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&opts.fix, "fix", false, "Fix errors in the CODEOWNERS file.")
+	cmd.Flags().BoolVar(&opts.json, "json", false, "Show errors as JSON.")
 	cmd.Flags().BoolVar(&opts.unknownOwners, "unknown-owners", false, "Only list unknown owners.")
-	cmd.MarkFlagsMutuallyExclusive("fix", "unknown-owners")
+	cmd.MarkFlagsMutuallyExclusive("fix", "json", "unknown-owners")
 
 	return cmd
 }
@@ -46,6 +55,7 @@ type lintOptions struct {
 	*GlobalOptions
 
 	fix           bool
+	json          bool
 	unknownOwners bool
 }
 
@@ -59,31 +69,33 @@ func lint(opts *lintOptions) (err error) {
 		return
 	}
 
-	var query struct {
-		Repository struct {
-			Codeowners struct {
-				Errors codeowners.Errors
-			} `graphql:"codeowners(refName: $ref)"`
-		} `graphql:"repository(owner: $owner, name: $repo)"`
-	}
-
 	refName, err := git.RefName()
 	if err != nil {
 		return
 	}
 
-	variables := map[string]interface{}{
-		"owner": graphql.String(opts.Repo.Owner()),
-		"repo":  graphql.String(opts.Repo.Name()),
-		"ref":   graphql.String(refName),
-	}
-	err = client.Query("CodeownersErrors", &query, variables)
+	errors, err := codeowners.QueryErrors(client, opts.Repo, refName)
 	if err != nil {
 		return
 	}
 
+	if opts.json {
+		buf, err := json.Marshal(errors)
+		if err != nil {
+			return err
+		}
+
+		r := bytes.NewBuffer(buf)
+		if opts.Console.IsStdoutTTY() {
+			return jsonpretty.Format(opts.Console.Stdout(), r, indent, opts.IsColorEnabled())
+		}
+
+		_, err = io.Copy(opts.Console.Stdout(), r)
+		return err
+	}
+
 	if opts.unknownOwners {
-		missing := query.Repository.Codeowners.Errors.UnknownOwners()
+		missing := errors.UnknownOwners()
 		for _, owner := range missing {
 			fmt.Fprintln(opts.Console.Stdout(), owner)
 		}
@@ -91,16 +103,37 @@ func lint(opts *lintOptions) (err error) {
 		return
 	}
 
-	linterOpts := codeowners.LintOptions{
-		Console: opts.Console,
-		Fix:     opts.fix,
-		Color:   opts.Color,
-	}
+	if opts.IsColorEnabled() {
+		cs := opts.Console.ColorScheme()
+		remove := cs.ColorFunc(opts.Color.Error)
 
-	root, err := git.RootFS()
-	if err != nil {
+		prettyPrint := func(e codeowners.Error) {
+			for _, line := range strings.Split(e.Message, "\n") {
+				if e.Kind == codeowners.ErrorKindUnknownOwner {
+					line = strings.TrimSpace(line)
+					if line == "^" {
+						fmt.Fprintln(opts.Console.Stdout())
+						return
+					} else if line == strings.TrimSpace(e.Source) {
+						owner := e.UnknownOwner()
+						line = indent + strings.ReplaceAll(line, owner, remove(owner))
+					}
+				}
+
+				fmt.Fprintln(opts.Console.Stdout(), line)
+			}
+		}
+
+		for _, e := range errors {
+			prettyPrint(e)
+		}
+
 		return
 	}
 
-	return codeowners.Lint(root, query.Repository.Codeowners.Errors, linterOpts)
+	for _, e := range errors {
+		fmt.Fprintln(opts.Console.Stdout(), e.Message)
+	}
+
+	return
 }

--- a/internal/cmd/options.go
+++ b/internal/cmd/options.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cli/go-gh"
 	"github.com/cli/go-gh/pkg/auth"
 	"github.com/cli/go-gh/pkg/repository"
+	"github.com/cli/go-gh/pkg/term"
 	"github.com/heaths/go-console"
 	"github.com/spf13/cobra"
 )
@@ -57,6 +58,12 @@ func (opts *GlobalOptions) IsAuthenticated() error {
 	}
 
 	return nil
+}
+
+func (opts *GlobalOptions) IsColorEnabled() bool {
+	return !term.IsColorDisabled() &&
+		opts.Console != nil &&
+		opts.Console.IsStdoutTTY()
 }
 
 func StringEnumVarP(cmd *cobra.Command, p *string, name, shorthand, defaultValue string, values []string, usage string) {

--- a/internal/cmd/view.go
+++ b/internal/cmd/view.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"github.com/cli/go-gh"
+	"github.com/cli/go-gh/pkg/api"
+	"github.com/heaths/gh-codeowners/internal/codeowners"
+	"github.com/heaths/gh-codeowners/internal/git"
+	"github.com/spf13/cobra"
+)
+
+func ViewCommand(globalOpts *GlobalOptions) *cobra.Command {
+	opts := &viewOptions{
+		GlobalOptions: globalOpts,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "view",
+		Short: "Views the CODEOWNERS file with errors highlighted",
+		Long:  "Checks your CODEOWNERS files for errors as determined by GitHub and renders the CODEOWNERS file.",
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			err = opts.EnsureRepository()
+			if err != nil {
+				return
+			}
+
+			err = opts.IsAuthenticated()
+			if err != nil {
+				return
+			}
+
+			return view(opts)
+		},
+	}
+
+	return cmd
+}
+
+type viewOptions struct {
+	*GlobalOptions
+}
+
+func view(opts *viewOptions) (err error) {
+	clientOpts := &api.ClientOptions{
+		Host:      opts.host,
+		AuthToken: opts.authToken,
+	}
+	client, err := gh.GQLClient(clientOpts)
+	if err != nil {
+		return
+	}
+
+	refName, err := git.RefName()
+	if err != nil {
+		return
+	}
+
+	errors, err := codeowners.QueryErrors(client, opts.Repo, refName)
+	if err != nil {
+		return
+	}
+
+	renderOpts := codeowners.RenderOptions{
+		Console: opts.Console,
+		Color:   opts.Color,
+	}
+
+	root, err := git.RootFS()
+	if err != nil {
+		return
+	}
+
+	return codeowners.Render(root, errors, renderOpts)
+}

--- a/internal/codeowners/render.go
+++ b/internal/codeowners/render.go
@@ -1,0 +1,62 @@
+package codeowners
+
+import (
+	"bufio"
+	"fmt"
+	_fs "io/fs"
+	"strings"
+
+	"github.com/heaths/go-console"
+)
+
+type RenderOptions struct {
+	Console console.Console
+	Fix     bool
+
+	Color struct {
+		Comment string
+		Error   string
+	}
+}
+
+func Render(fs _fs.FS, errors Errors, opts RenderOptions) error {
+	path := errors.Path()
+	if path == "" {
+		return nil
+	}
+
+	file, err := fs.Open(path)
+	if err != nil {
+		return err
+	}
+
+	cs := opts.Console.ColorScheme()
+	remove := cs.ColorFunc(opts.Color.Error)
+	comment := cs.ColorFunc(opts.Color.Comment)
+
+	linenum := 0
+	missing := errors.indexUnknownOwners()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		linenum++
+
+		line := scanner.Text()
+
+		if opts.Console.IsStdoutTTY() {
+			if owners, ok := missing[linenum]; ok {
+				for _, owner := range owners {
+					line = strings.ReplaceAll(line, owner, remove(owner))
+				}
+			}
+
+			if idx := strings.IndexRune(line, '#'); idx >= 0 {
+				line = line[:idx] + comment(line[idx:])
+			}
+		}
+
+		fmt.Fprintln(opts.Console.Stdout(), line)
+	}
+
+	return nil
+}

--- a/internal/codeowners/render_test.go
+++ b/internal/codeowners/render_test.go
@@ -1,0 +1,96 @@
+package codeowners
+
+import (
+	"bytes"
+	"testing"
+	"testing/fstest"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/heaths/go-console"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRender(t *testing.T) {
+	var source = heredoc.Doc(`
+		# License
+
+		* @default # Default owner(s)
+		docs/** @writers @unknown
+	`)
+
+	const path = ".github/CODEOWNERS"
+	mockFS := fstest.MapFS{
+		path: {Data: []byte(source)},
+	}
+
+	tests := []struct {
+		name    string
+		errors  Errors
+		tty     bool
+		want    string
+		wantErr string
+	}{
+		{
+			name: "unknown owner",
+			errors: Errors{
+				{
+					Kind:   ErrorKindUnknownOwner,
+					Line:   4,
+					Column: 18,
+					Source: "docs/** @writers @unknown",
+					Path:   path,
+				},
+			},
+			want: source,
+		},
+		{
+			name: "unknown owner (tty)",
+			errors: Errors{
+				{
+					Kind:   ErrorKindUnknownOwner,
+					Line:   4,
+					Column: 18,
+					Source: "docs/** @writers @unknown",
+					Path:   path,
+				},
+			},
+			tty: true,
+			want: heredoc.Docf(`
+				%[1]s[0;38;2;0;255;0m# License%[1]s[0m
+
+				* @default %[1]s[0;38;2;0;255;0m# Default owner(s)%[1]s[0m
+				docs/** @writers %[1]s[0;38;2;255;0;0m@unknown%[1]s[0m
+			`, "\033"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stdout := &bytes.Buffer{}
+			con := console.Fake(
+				console.WithStdout(stdout),
+				console.WithStdoutTTY(tt.tty),
+			)
+
+			opts := RenderOptions{
+				Console: con,
+				Color: struct {
+					Comment string
+					Error   string
+				}{
+					Comment: "#00FF00",
+					Error:   "#FF0000",
+				},
+			}
+
+			err := Render(mockFS, tt.errors, opts)
+			if tt.wantErr != "" {
+				assert.EqualError(t, err, tt.wantErr)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, stdout.String())
+		})
+	}
+}


### PR DESCRIPTION
Refactors the CODEOWNERS rendering to a new `view` command and updates the `lint` command to only render the raw message (colorized, when possible), unknown owners or - new - the raw JSON.
